### PR TITLE
Use native bridge for animations

### DIFF
--- a/NavigationAnimatedView.js
+++ b/NavigationAnimatedView.js
@@ -53,6 +53,7 @@ function applyDefaultAnimation(
   Animated.spring(
     position,
     {
+      useNativeDriver: true,
       bounciness: 0,
       toValue: navigationState.index,
     }
@@ -228,8 +229,14 @@ class NavigationAnimatedView
       isMeasured: true,
     };
 
-    layout.height.setValue(height);
-    layout.width.setValue(width);
+    Animated.event([{
+      nativeEvent: {
+        layout: {
+          height: height,
+          width: width,
+        },
+      },
+    }]);
 
     this.setState({ layout });
   }


### PR DESCRIPTION
**Motivation:** 
Rendering inconsistencies / slowness between screens in Android:
https://github.com/aksonov/react-native-router-flux/issues/199
https://github.com/aksonov/react-native-router-flux/issues/1177
https://github.com/aksonov/react-native-router-flux/issues/1266

**Fix**
Basically patches in the change from https://github.com/facebook/react-native/pull/10289/files.

Once the above commit is merged into RN and pushed to a stable release, this can be merged. It won't be backwards compatible with older versions of RN, however.

I don't know how critical this fork is to the overall react-native-router-flux implementation, but long term it would probably be good to move off this fork altogether, or at least try to keep it up to date with the actual implementation of ExperimentalNavigation.

@aksonov would appreciate guidance here if you have thoughts?
